### PR TITLE
aggregation of javadoc works different since mavan-javadoc-plugin:3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -563,7 +563,6 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.5.0</version>
                     <configuration>
-                        <aggregate>true</aggregate>
                         <maxmemory>600m</maxmemory>
                         <links>
                             <link>https://docs.oracle.com/javase/8/docs/api/</link>
@@ -747,6 +746,31 @@
         </plugins>
 
     </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.5.0</version>
+                <reportSets>
+                    <reportSet>
+                        <id>aggregate</id>
+                        <inherited>false</inherited>
+                        <reports>
+                            <report>aggregate</report>
+                        </reports>
+                    </reportSet>
+                    <reportSet>
+                        <id>default</id>
+                        <reports>
+                            <report>javadoc</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
 
     <developers>
         <developer>


### PR DESCRIPTION
It seems I broke your javadoc generation with the latest maven plugins update.
This should fix it.
That's the reference documentation: https://maven.apache.org/plugins/maven-javadoc-plugin/examples/aggregate.html
Please check and merge if okay.