### PR TITLE
SNAP-3539 - removed old JUnit

### DIFF
--- a/sar-io/src/test/java/eu/esa/sar/io/ceos/records/BaseRecordTest.java
+++ b/sar-io/src/test/java/eu/esa/sar/io/ceos/records/BaseRecordTest.java
@@ -15,45 +15,29 @@
  */
 package eu.esa.sar.io.ceos.records;
 
-import junit.framework.TestCase;
 import eu.esa.sar.io.binary.BinaryFileReader;
 import eu.esa.sar.io.binary.BinaryRecord;
 import eu.esa.sar.io.binary.IllegalBinaryFormatException;
 import org.esa.snap.core.datamodel.MetadataAttribute;
 import org.esa.snap.core.datamodel.MetadataElement;
 import org.esa.snap.core.datamodel.ProductData;
+import org.junit.Before;
+import org.junit.Test;
 
 import javax.imageio.stream.ImageOutputStream;
 import java.io.IOException;
 
-public class BaseRecordTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class BaseRecordTest {
 
     public static final int RECORD_LENGTH = 4680;
+    private static final String format = "ers";
+    private static final String recordDefinitionFile = "volume_descriptor.xml";
     private ImageOutputStream _ios;
     private String _prefix;
     private BinaryFileReader _reader;
-
-    private static String format = "ers";
-    private static String recordDefinitionFile = "volume_descriptor.xml";
-
-    protected void setUp() throws Exception {
-   /*     final ByteArrayOutputStream os = new ByteArrayOutputStream(24);
-        _ios = new MemoryCacheImageOutputStream(os);
-        _prefix = "BaseRecordTest_prefix";
-        _ios.writeBytes(_prefix);
-        writeRecordData(_ios);
-        _ios.writeBytes("BaseRecordTest_suffix"); // as suffix
-        _reader = new BinaryFileReader(_ios); */
-    }
-
-    public void testInitBaseRecord() throws IOException, IllegalBinaryFormatException {
-   /*     final BinaryRecord record = new BinaryRecord(_reader, _prefix.length(), format, recordDefinitionFile);
-
-        assertRecord(record);
-        assertSame(_reader, record.getReader());
-        assertEquals(_prefix.length(), record.getStartPos());
-        assertEquals(_prefix.length() + 12, _ios.getStreamPosition());  */
-    }
 
     /*
     public void testAssignMetadataTo() throws IOException,
@@ -109,6 +93,27 @@ public class BaseRecordTest extends TestCase {
         ios.write(022); // secondRecordSubtype = 22 octal
         ios.write(021); // thirdRecordSubtype = 22 octal (21 octal only for test)
         ios.writeInt(RECORD_LENGTH); // recordLength = variable
+    }
+
+    @Before
+    public void setUp() throws Exception {
+   /*     final ByteArrayOutputStream os = new ByteArrayOutputStream(24);
+        _ios = new MemoryCacheImageOutputStream(os);
+        _prefix = "BaseRecordTest_prefix";
+        _ios.writeBytes(_prefix);
+        writeRecordData(_ios);
+        _ios.writeBytes("BaseRecordTest_suffix"); // as suffix
+        _reader = new BinaryFileReader(_ios); */
+    }
+
+    @Test
+    public void testInitBaseRecord() throws IOException, IllegalBinaryFormatException {
+   /*     final BinaryRecord record = new BinaryRecord(_reader, _prefix.length(), format, recordDefinitionFile);
+
+        assertRecord(record);
+        assertSame(_reader, record.getReader());
+        assertEquals(_prefix.length(), record.getStartPos());
+        assertEquals(_prefix.length() + 12, _ios.getStreamPosition());  */
     }
    /*
     public void testCreateMetadataElement() {

--- a/sar-io/src/test/java/eu/esa/sar/io/ceos/records/FilePointerRecordTest.java
+++ b/sar-io/src/test/java/eu/esa/sar/io/ceos/records/FilePointerRecordTest.java
@@ -15,70 +15,31 @@
  */
 package eu.esa.sar.io.ceos.records;
 
-import junit.framework.TestCase;
 import eu.esa.sar.io.binary.BinaryDBReader;
 import eu.esa.sar.io.binary.BinaryFileReader;
 import eu.esa.sar.io.binary.IllegalBinaryFormatException;
 import eu.esa.sar.io.ceos.FilePointerRecord;
 import org.esa.snap.core.datamodel.MetadataElement;
 import org.jdom2.Document;
+import org.junit.Before;
+import org.junit.Test;
 
 import javax.imageio.stream.ImageOutputStream;
 import javax.imageio.stream.MemoryCacheImageOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-public class FilePointerRecordTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-    private ImageOutputStream _ios;
-    private String _prefix;
-    private BinaryFileReader _reader;
+public class FilePointerRecordTest {
 
     private final static String mission = "ers";
     private final static String filePointerDefinitionFile = "file_pointer_record.xml";
     private final static Document filePointerXML = BinaryDBReader.loadDefinitionFile(mission, filePointerDefinitionFile);
-
-    protected void setUp() throws Exception {
-        final ByteArrayOutputStream os = new ByteArrayOutputStream(24);
-        _ios = new MemoryCacheImageOutputStream(os);
-        _prefix = "fdkjglsdkfhierr.m b9b0970w34";
-        _ios.writeBytes(_prefix);
-        writeRecordData(_ios);
-        _ios.writeBytes("nq3tf9ß8nvnvpdi er 0 324p3f"); // as suffix
-        _reader = new BinaryFileReader(_ios);
-    }
-
-    public void testInit_SimpleConstructor() throws IOException, IllegalBinaryFormatException {
-        _ios.seek(_prefix.length());
-        final FilePointerRecord record = new FilePointerRecord(_reader, filePointerXML, filePointerDefinitionFile);
-
-        assertRecord(record);
-        assertEquals(_prefix.length(), record.getStartPos());
-        assertEquals(_prefix.length() + 360, _ios.getStreamPosition());
-    }
-
-    public void testInit() throws IOException, IllegalBinaryFormatException {
-        final FilePointerRecord record = new FilePointerRecord(_reader, filePointerXML, _prefix.length(), filePointerDefinitionFile);
-
-        assertRecord(record);
-        assertEquals(_prefix.length(), record.getStartPos());
-        assertEquals(_prefix.length() + 360, _ios.getStreamPosition());
-    }
-
-    public void testAssignMetadataTo() throws IOException, IllegalBinaryFormatException {
-        final FilePointerRecord record = new FilePointerRecord(_reader, filePointerXML, _prefix.length(), filePointerDefinitionFile);
-        final MetadataElement elem = new MetadataElement("elem");
-
-        record.assignMetadataTo(elem, "suffix");
-
-        assertEquals(0, elem.getNumAttributes());
-        assertEquals(1, elem.getNumElements());
-        final MetadataElement recordRoot = elem.getElement("FilePointerRecord suffix");
-        assertNotNull(recordRoot);
-        assertMetadata(recordRoot);
-        assertEquals(0, recordRoot.getNumElements());
-        assertEquals(17, recordRoot.getNumAttributes());
-    }
+    private ImageOutputStream _ios;
+    private String _prefix;
+    private BinaryFileReader _reader;
 
     public static void assertMetadata(final MetadataElement elem) {
         BaseRecordTest.assertMetadata(elem);
@@ -149,5 +110,51 @@ public class FilePointerRecordTest extends TestCase {
                 "                                                  " +
                 "                                                  " +
                 "                                                  "); // A208
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        final ByteArrayOutputStream os = new ByteArrayOutputStream(24);
+        _ios = new MemoryCacheImageOutputStream(os);
+        _prefix = "fdkjglsdkfhierr.m b9b0970w34";
+        _ios.writeBytes(_prefix);
+        writeRecordData(_ios);
+        _ios.writeBytes("nq3tf9ß8nvnvpdi er 0 324p3f"); // as suffix
+        _reader = new BinaryFileReader(_ios);
+    }
+
+    @Test
+    public void testInit_SimpleConstructor() throws IOException, IllegalBinaryFormatException {
+        _ios.seek(_prefix.length());
+        final FilePointerRecord record = new FilePointerRecord(_reader, filePointerXML, filePointerDefinitionFile);
+
+        assertRecord(record);
+        assertEquals(_prefix.length(), record.getStartPos());
+        assertEquals(_prefix.length() + 360, _ios.getStreamPosition());
+    }
+
+    @Test
+    public void testInit() throws IOException {
+        final FilePointerRecord record = new FilePointerRecord(_reader, filePointerXML, _prefix.length(), filePointerDefinitionFile);
+
+        assertRecord(record);
+        assertEquals(_prefix.length(), record.getStartPos());
+        assertEquals(_prefix.length() + 360, _ios.getStreamPosition());
+    }
+
+    @Test
+    public void testAssignMetadataTo() throws IOException {
+        final FilePointerRecord record = new FilePointerRecord(_reader, filePointerXML, _prefix.length(), filePointerDefinitionFile);
+        final MetadataElement elem = new MetadataElement("elem");
+
+        record.assignMetadataTo(elem, "suffix");
+
+        assertEquals(0, elem.getNumAttributes());
+        assertEquals(1, elem.getNumElements());
+        final MetadataElement recordRoot = elem.getElement("FilePointerRecord suffix");
+        assertNotNull(recordRoot);
+        assertMetadata(recordRoot);
+        assertEquals(0, recordRoot.getNumElements());
+        assertEquals(17, recordRoot.getNumAttributes());
     }
 }

--- a/sar-io/src/test/java/eu/esa/sar/io/ceos/records/TextRecordTest.java
+++ b/sar-io/src/test/java/eu/esa/sar/io/ceos/records/TextRecordTest.java
@@ -15,56 +15,32 @@
  */
 package eu.esa.sar.io.ceos.records;
 
-import junit.framework.TestCase;
 import eu.esa.sar.io.binary.BinaryDBReader;
 import eu.esa.sar.io.binary.BinaryFileReader;
 import eu.esa.sar.io.binary.BinaryRecord;
-import eu.esa.sar.io.binary.IllegalBinaryFormatException;
 import eu.esa.sar.io.ceos.CeosTestHelper;
 import org.jdom2.Document;
+import org.junit.Before;
+import org.junit.Test;
 
 import javax.imageio.stream.ImageOutputStream;
 import javax.imageio.stream.MemoryCacheImageOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * @noinspection OctalInteger
  */
-public class TextRecordTest extends TestCase {
-
-    private MemoryCacheImageOutputStream _ios;
-    private String _prefix;
-    private BinaryFileReader _reader;
+public class TextRecordTest {
 
     private final static String mission = "ers";
     private final static String text_recordDefinitionFile = "text_record.xml";
-
     private final static Document textRecXML = BinaryDBReader.loadDefinitionFile(mission, text_recordDefinitionFile);
-
-    @Override
-    protected void setUp() throws Exception {
-        final ByteArrayOutputStream os = new ByteArrayOutputStream(24);
-        _ios = new MemoryCacheImageOutputStream(os);
-        _prefix = "TextRecordTest_prefix";
-        _ios.writeBytes(_prefix);
-        writeRecordData(_ios);
-        _ios.writeBytes("TextRecordTest_suffix"); // as suffix
-        _reader = new BinaryFileReader(_ios);
-    }
-
-    public void testInit_SimpleConstructor() throws IOException, IllegalBinaryFormatException {
-        _reader.seek(_prefix.length());
-        final BinaryRecord textRecord = new BinaryRecord(_reader, -1, textRecXML, text_recordDefinitionFile);
-
-        assertRecord(textRecord);
-    }
-
-    public void testInit() throws IOException, IllegalBinaryFormatException {
-        final BinaryRecord textRecord = new BinaryRecord(_reader, _prefix.length(), textRecXML, text_recordDefinitionFile);
-
-        assertRecord(textRecord);
-    }
+    private MemoryCacheImageOutputStream _ios;
+    private String _prefix;
+    private BinaryFileReader _reader;
 
     private static void writeRecordData(final ImageOutputStream ios) throws IOException {
         BaseRecordTest.writeRecordData(ios);
@@ -81,6 +57,32 @@ public class TextRecordTest extends TestCase {
         CeosTestHelper.writeBlanks(ios, 200);
     }
 
+    @Before
+    public void setUp() throws Exception {
+        final ByteArrayOutputStream os = new ByteArrayOutputStream(24);
+        _ios = new MemoryCacheImageOutputStream(os);
+        _prefix = "TextRecordTest_prefix";
+        _ios.writeBytes(_prefix);
+        writeRecordData(_ios);
+        _ios.writeBytes("TextRecordTest_suffix"); // as suffix
+        _reader = new BinaryFileReader(_ios);
+    }
+
+    @Test
+    public void testInit_SimpleConstructor() throws IOException {
+        _reader.seek(_prefix.length());
+        final BinaryRecord textRecord = new BinaryRecord(_reader, -1, textRecXML, text_recordDefinitionFile);
+
+        assertRecord(textRecord);
+    }
+
+    @Test
+    public void testInit() throws IOException {
+        final BinaryRecord textRecord = new BinaryRecord(_reader, _prefix.length(), textRecXML, text_recordDefinitionFile);
+
+        assertRecord(textRecord);
+    }
+
     private void assertRecord(final BinaryRecord record) throws IOException {
         BaseRecordTest.assertRecord(record);
         assertEquals(_prefix.length(), record.getStartPos());
@@ -90,6 +92,5 @@ public class TextRecordTest extends TestCase {
         assertEquals("PRODUCT:O1B2R_UB                        ", record.getAttributeString("Product type specifier"));
         assertEquals("PROCESS:JAPAN-JAXA-EOC-ALOS-DPS  20060410075225             ",
                 record.getAttributeString("Location and datetime of product creation"));
-
     }
 }

--- a/sar-io/src/test/java/eu/esa/sar/io/ceos/records/VolumeDescriptorRecordTest.java
+++ b/sar-io/src/test/java/eu/esa/sar/io/ceos/records/VolumeDescriptorRecordTest.java
@@ -15,64 +15,29 @@
  */
 package eu.esa.sar.io.ceos.records;
 
-import junit.framework.TestCase;
 import eu.esa.sar.io.binary.BinaryDBReader;
 import eu.esa.sar.io.binary.BinaryFileReader;
 import eu.esa.sar.io.binary.BinaryRecord;
-import eu.esa.sar.io.binary.IllegalBinaryFormatException;
 import eu.esa.sar.io.ceos.CeosTestHelper;
 import org.esa.snap.core.datamodel.MetadataElement;
 import org.jdom2.Document;
+import org.junit.Before;
+import org.junit.Test;
 
 import javax.imageio.stream.MemoryCacheImageOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-public class VolumeDescriptorRecordTest extends TestCase {
+import static org.junit.Assert.assertEquals;
 
+public class VolumeDescriptorRecordTest {
+
+    private static final String mission = "ers";
+    private static final String volume_desc_recordDefinitionFile = "volume_descriptor.xml";
+    private final static Document volDescXML = BinaryDBReader.loadDefinitionFile(mission, volume_desc_recordDefinitionFile);
     private MemoryCacheImageOutputStream _ios;
     private String _prefix;
     private BinaryFileReader _reader;
-
-    private static String mission = "ers";
-    private static String volume_desc_recordDefinitionFile = "volume_descriptor.xml";
-
-    private final static Document volDescXML = BinaryDBReader.loadDefinitionFile(mission, volume_desc_recordDefinitionFile);
-
-
-    protected void setUp() throws Exception {
-        final ByteArrayOutputStream os = new ByteArrayOutputStream(24);
-        _ios = new MemoryCacheImageOutputStream(os);
-        _prefix = "VolumeDescriptorRecordTest_prefix";
-        _ios.writeBytes(_prefix);
-        writeRecordData(_ios);
-        _ios.writeBytes("VolumeDescriptorRecordTest_suffix"); // suffix
-        _reader = new BinaryFileReader(_ios);
-    }
-
-    public void testInit_SimpleConstructor() throws IOException, IllegalBinaryFormatException {
-        _reader.seek(_prefix.length());
-        final BinaryRecord record = new BinaryRecord(_reader, -1, volDescXML, volume_desc_recordDefinitionFile);
-
-        assertRecord(record);
-    }
-
-    public void testInit() throws IOException, IllegalBinaryFormatException {
-        final BinaryRecord record = new BinaryRecord(_reader, _prefix.length(), volDescXML, volume_desc_recordDefinitionFile);
-
-        assertRecord(record);
-    }
-
-    public void testAssignMetadata() throws IOException, IllegalBinaryFormatException {
-        final BinaryRecord record = new BinaryRecord(_reader, _prefix.length(), volDescXML, volume_desc_recordDefinitionFile);
-        final MetadataElement volumeMetadata = new MetadataElement("VOLUME_DESCRIPTOR");
-
-        record.assignMetadataTo(volumeMetadata);
-
-        assertEquals(21, volumeMetadata.getNumAttributes());
-        assertEquals(0, volumeMetadata.getNumElements());
-        assertMetadata(volumeMetadata);
-    }
 
     private static void assertMetadata(final MetadataElement elem) {
         BaseRecordTest.assertMetadata(elem);
@@ -122,6 +87,44 @@ public class VolumeDescriptorRecordTest extends TestCase {
         ios.writeBytes("5678"); // nuberOfRecords // I4
         ios.writeBytes("5"); // Total number of logical volume set // I4
         CeosTestHelper.writeBlanks(ios, 192); // blank
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        final ByteArrayOutputStream os = new ByteArrayOutputStream(24);
+        _ios = new MemoryCacheImageOutputStream(os);
+        _prefix = "VolumeDescriptorRecordTest_prefix";
+        _ios.writeBytes(_prefix);
+        writeRecordData(_ios);
+        _ios.writeBytes("VolumeDescriptorRecordTest_suffix"); // suffix
+        _reader = new BinaryFileReader(_ios);
+    }
+
+    @Test
+    public void testInit_SimpleConstructor() throws IOException {
+        _reader.seek(_prefix.length());
+        final BinaryRecord record = new BinaryRecord(_reader, -1, volDescXML, volume_desc_recordDefinitionFile);
+
+        assertRecord(record);
+    }
+
+    @Test
+    public void testInit() throws IOException {
+        final BinaryRecord record = new BinaryRecord(_reader, _prefix.length(), volDescXML, volume_desc_recordDefinitionFile);
+
+        assertRecord(record);
+    }
+
+    @Test
+    public void testAssignMetadata() throws IOException {
+        final BinaryRecord record = new BinaryRecord(_reader, _prefix.length(), volDescXML, volume_desc_recordDefinitionFile);
+        final MetadataElement volumeMetadata = new MetadataElement("VOLUME_DESCRIPTOR");
+
+        record.assignMetadataTo(volumeMetadata);
+
+        assertEquals(21, volumeMetadata.getNumAttributes());
+        assertEquals(0, volumeMetadata.getNumElements());
+        assertMetadata(volumeMetadata);
     }
 
     private void assertRecord(final BinaryRecord record) throws IOException {

--- a/sar-io/src/test/java/eu/esa/sar/io/uavsar/TestUAVSARReader.java
+++ b/sar-io/src/test/java/eu/esa/sar/io/uavsar/TestUAVSARReader.java
@@ -1,36 +1,31 @@
-
 package eu.esa.sar.io.uavsar;
 
-import junit.framework.TestCase;
 import org.esa.snap.core.dataio.DecodeQualification;
 import org.esa.snap.core.dataio.ProductReader;
 import org.esa.snap.core.datamodel.Product;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.File;
 
-public class TestUAVSARReader extends TestCase {
+import static org.junit.Assert.assertSame;
+
+public class TestUAVSARReader {
 
     private final static File inputFile = new File("I:\\ESA-Data\\UAVSAR\\UA_HaitiQ_05701_10011_008_100127_L090_CX_01\\HaitiQ_05701_10011_008_100127_L090HHHH_CX_01.mlc");
 
     private UAVSARReaderPlugIn readerPlugin;
     private ProductReader reader;
 
-    public TestUAVSARReader(String name) {
-        super(name);
-    }
-
-    @Override
+    @Before
     public void setUp() throws Exception {
-        super.setUp();
-
         readerPlugin = new UAVSARReaderPlugIn();
         reader = readerPlugin.createReaderInstance();
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-
+    @After
+    public void tearDown() {
         reader = null;
         readerPlugin = null;
     }
@@ -40,10 +35,11 @@ public class TestUAVSARReader extends TestCase {
      *
      * @throws Exception anything
      */
+    @Test
     public void testOpen() throws Exception {
         if (!inputFile.exists()) return;
 
-        assertTrue(readerPlugin.getDecodeQualification(inputFile) == DecodeQualification.INTENDED);
+        assertSame(readerPlugin.getDecodeQualification(inputFile), DecodeQualification.INTENDED);
 
         final Product product = reader.readProductNodes(inputFile, null);
         //TestUtils.verifyProduct(product, true, true);

--- a/sar-op-feature-extraction/src/test/java/eu/esa/sar/fex/gpf/decisiontree/TestDescisionTreeOp.java
+++ b/sar-op-feature-extraction/src/test/java/eu/esa/sar/fex/gpf/decisiontree/TestDescisionTreeOp.java
@@ -1,69 +1,24 @@
-
 package eu.esa.sar.fex.gpf.decisiontree;
 
-import junit.framework.TestCase;
 import org.esa.snap.core.datamodel.*;
 import org.esa.snap.core.gpf.OperatorSpi;
 import org.esa.snap.engine_utilities.datamodel.AbstractMetadata;
 import org.esa.snap.engine_utilities.datamodel.Unit;
 import org.esa.snap.engine_utilities.gpf.OperatorUtils;
 import org.esa.snap.engine_utilities.util.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.Arrays;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Unit test for DecisionTreeOp.
  */
-public class TestDescisionTreeOp extends TestCase {
+public class TestDescisionTreeOp {
 
     private OperatorSpi spi;
-
-    @Override
-    protected void setUp() {
-        spi = new DecisionTreeOp.Spi();
-    }
-
-    public void testMultilookOfRealImage() throws Exception {
-
-        final Product sourceProduct = createTestProduct(16, 4);
-
-        final DecisionTreeOp op = (DecisionTreeOp) spi.createOperator();
-        assertNotNull(op);
-        op.setSourceProduct(sourceProduct);
-
-
-
-     /*   op.setNumRangeLooks(4);
-        MultilookOp.DerivedParams param = new MultilookOp.DerivedParams();
-        param.nRgLooks = 4;
-        op.getDerivedParameters(sourceProduct, param);
-        op.setNumAzimuthLooks(param.nAzLooks);
-
-        // get targetProduct: execute initialize()
-        final Product targetProduct = op.getTargetProduct();
-        TestUtils.verifyProduct(targetProduct, true, true);
-
-        final Band band = targetProduct.getBandAt(0);
-        assertNotNull(band);
-
-        // readPixels: execute computeTiles()
-        final float[] floatValues = new float[8];
-        band.readPixels(0, 0, 4, 2, floatValues, ProgressMonitor.NULL);
-
-        // compare with expected outputs:
-        final float[] expectedValues = {10.5f, 14.5f, 18.5f, 22.5f, 42.5f, 46.5f, 50.5f, 54.5f};
-        assertArrayEquals(Arrays.toString(floatValues), expectedValues, floatValues, 0.0001f);
-
-        // compare updated metadata
-        final MetadataElement abs = AbstractMetadata.getAbstractedMetadata(targetProduct);
-
-        TestUtils.attributeEquals(abs, AbstractMetadata.azimuth_looks, 2.0);
-        TestUtils.attributeEquals(abs, AbstractMetadata.range_looks, 4.0);
-        TestUtils.attributeEquals(abs, AbstractMetadata.azimuth_spacing, 4.0);
-        TestUtils.attributeEquals(abs, AbstractMetadata.range_spacing, 2.0);
-        TestUtils.attributeEquals(abs, AbstractMetadata.line_time_interval, 0.02);
-        TestUtils.attributeEquals(abs, AbstractMetadata.first_line_time, "10-MAY-2008 20:32:46.890683");      */
-    }
 
     /**
      * Creates a 4-by-16 test product as shown below:
@@ -110,4 +65,51 @@ public class TestDescisionTreeOp extends TestCase {
         return testProduct;
     }
 
+    @Before
+    public void setUp() {
+        spi = new DecisionTreeOp.Spi();
+    }
+
+    @Test
+    public void testMultilookOfRealImage() {
+
+        final Product sourceProduct = createTestProduct(16, 4);
+
+        final DecisionTreeOp op = (DecisionTreeOp) spi.createOperator();
+        assertNotNull(op);
+        op.setSourceProduct(sourceProduct);
+
+
+
+     /*   op.setNumRangeLooks(4);
+        MultilookOp.DerivedParams param = new MultilookOp.DerivedParams();
+        param.nRgLooks = 4;
+        op.getDerivedParameters(sourceProduct, param);
+        op.setNumAzimuthLooks(param.nAzLooks);
+
+        // get targetProduct: execute initialize()
+        final Product targetProduct = op.getTargetProduct();
+        TestUtils.verifyProduct(targetProduct, true, true);
+
+        final Band band = targetProduct.getBandAt(0);
+        assertNotNull(band);
+
+        // readPixels: execute computeTiles()
+        final float[] floatValues = new float[8];
+        band.readPixels(0, 0, 4, 2, floatValues, ProgressMonitor.NULL);
+
+        // compare with expected outputs:
+        final float[] expectedValues = {10.5f, 14.5f, 18.5f, 22.5f, 42.5f, 46.5f, 50.5f, 54.5f};
+        assertArrayEquals(Arrays.toString(floatValues), expectedValues, floatValues, 0.0001f);
+
+        // compare updated metadata
+        final MetadataElement abs = AbstractMetadata.getAbstractedMetadata(targetProduct);
+
+        TestUtils.attributeEquals(abs, AbstractMetadata.azimuth_looks, 2.0);
+        TestUtils.attributeEquals(abs, AbstractMetadata.range_looks, 4.0);
+        TestUtils.attributeEquals(abs, AbstractMetadata.azimuth_spacing, 4.0);
+        TestUtils.attributeEquals(abs, AbstractMetadata.range_spacing, 2.0);
+        TestUtils.attributeEquals(abs, AbstractMetadata.line_time_interval, 0.02);
+        TestUtils.attributeEquals(abs, AbstractMetadata.first_line_time, "10-MAY-2008 20:32:46.890683");      */
+    }
 }


### PR DESCRIPTION
Besides removing the old JUint pattern, I found a lot of code that is commented out. Can this be re-activated or removed?