### PR TITLE
fix: Remove pluginRepositories def

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         </repository>
     </repositories>
 
-    <pluginRepositories>
+    <!-- <pluginRepositories>
         <pluginRepository>
             <id>snap-repo-public</id>
             <name>Public Maven Repository for SNAP</name>
@@ -138,7 +138,7 @@
                 <checksumPolicy>warn</checksumPolicy>
             </snapshots>
         </pluginRepository>
-    </pluginRepositories>
+    </pluginRepositories> -->
 
     <distributionManagement>
         <repository>


### PR DESCRIPTION
As described [here](https://robinhowlett.com/blog/2019/05/15/solved-when-the-maven-deploy-plugin-silently-fails-to-deploy/) `pluginRepositories` can cause artifacts deplyment failing silently