### PR TITLE
SNAP-3552-Graph-Builder-parameter-values-not-loaded-from-the-graph-for-some-operators

### DIFF
--- a/sar-op-utilities-ui/src/main/java/eu/esa/sar/utilities/gpf/ui/BandSelectOpUI.java
+++ b/sar-op-utilities-ui/src/main/java/eu/esa/sar/utilities/gpf/ui/BandSelectOpUI.java
@@ -93,7 +93,7 @@ public class BandSelectOpUI extends BaseOperatorUI {
             });
         }
 
-        OperatorUIUtils.initParamList(bandList, getBandNames());
+        OperatorUIUtils.initParamList(bandList, getBandNames(), (Object[])paramMap.get("sourceBands"));
 
         bandNamePattern.setText((String)paramMap.get("bandNamePattern"));
 
@@ -141,7 +141,7 @@ public class BandSelectOpUI extends BaseOperatorUI {
         OperatorUIUtils.updateParamList(polList, paramMap, "selectedPolarisations");
         OperatorUIUtils.updateParamList(subImageList, paramMap, "selectedSubImages");
         OperatorUIUtils.updateParamList(bandList, paramMap, OperatorUIUtils.SOURCE_BAND_NAMES);
-        OperatorUIUtils.updateParamList(maskList, paramMap, "sourceMasks");
+        OperatorUIUtils.updateParamList(maskList, paramMap, "sourceMaskNames");
 
         paramMap.put("bandNamePattern", bandNamePattern.getText());
     }


### PR DESCRIPTION
SNAP-3552 - Load the values defined in the XML graph for BandSelectOp (sourceBand)